### PR TITLE
Use linux Miniconda installer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,8 @@ pipeline {
             steps {
                 deleteDir()
                 checkout scm
-
-				sh("curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o installer.sh")
+                sh("curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o installer.sh")
+		         https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
                 sh("bash installer.sh -b -p ${WORKSPACE}/miniconda3")
                 sh("conda create -n simcal python -y")
             }


### PR DESCRIPTION
It looks like this job is now getting farmed out to `nott.stsci.edu`, which is a Linux machine, so we should use the linux Miniconda installer.

If possible, it would be nice to have some control over which type of machine actually runs this Jenkins job.  Will have to look into that.